### PR TITLE
Makefile targets maintenance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,4 @@ before_script:
     - "sh -e /etc/init.d/xvfb start"
     - "sleep 3"
 script:
-    - "make build"
+    - "make lint test"

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ lib_files = $(shell find lib -name "*.js")
 test_files = $(shell find test -name "*.spec.js")
 covered_files = $(addprefix build/covered/,$(lib_files))
 
-build: build/install build/lint build/test
+build: build/install build/macgyver.js
 lint: build/install build/lint
 test: build/install build/test
 dist: dist/macgyver.js
@@ -40,7 +40,11 @@ build/lint: $(lib_files) $(test_files)
 
 build/test: build/macgyver.js $(test_files) karma.conf.js
 	mkdir -p $@
-	BUNDLE=build/macgyver.js TEST_FILES="$(test_files)" COV_DIR=$@ $(NODE_BIN_DIR)/karma start
+ifdef TRAVIS
+	$(NODE_BIN_DIR)/karma start --browsers Chrome_Travis
+else
+	$(NODE_BIN_DIR)/karma start --browsers Chrome --log-level error
+endif
 	$(NODE_BIN_DIR)/istanbul report --dir $@/coverage --root $@ html
 	touch $@
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,41 +1,22 @@
-// These environment variable should be defined in the Makefile
-// or passed onto the command line variable.
-var bundle = process.env.BUNDLE;
-var tests = process.env.TEST_FILES;
-var coverageDir = process.env.COV_DIR;
-
 module.exports = function(config) {
-    if (!bundle) {
-        throw new Error('BUNDLE is not defined');
-    }
-
-    if (!tests) {
-        throw new Error('TEST_FILES is not defined');
-    }
-
-    if (!coverageDir) {
-        throw new Error('COV_DIR is not defined');
-    }
-
-    var files = [].concat(bundle.split(' '), tests.split(' '));
-
     config.set({
         basePath: './',
         autoWatch: false,
         singleRun: true,
-        logLevel: config.LOG_ERROR,
         frameworks: ['mocha', 'chai'],
-        browsers: process.env.TRAVIS ? ['Chrome_Travis'] : ['Chrome'],
         customLaunchers: {
             Chrome_Travis: {
                 base: 'Chrome',
                 flags: ['--no-sandbox']
             }
         },
-        files: files,
+        files: [
+            'build/macgyver.js',
+            'test/macgyver.spec.js'
+        ],
         reporters: ['coverage', 'mocha'],
         coverageReporter: {
-            dir: coverageDir,
+            dir: 'build/test',
             reporters: [
                 {type: 'json', subdir: '.'}
             ]


### PR DESCRIPTION
1.  Separate `build` from `test`
    build only generates the covered bundle now

2.  As a result, Travis needs to explicitly run `make lint test`
    for validating pull requests

3.  Removed Travis switches out of karma configuration and put them
    in the Makefile

4.  Since you can only run karma through Make, there's no point
    in communicating paths through environment variables.
    Deleted those and hardcoded the path in
    the karma config file directly